### PR TITLE
Removed check that caused all assets to generate script tags in dev environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,6 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const uniq = require('lodash/uniq');
 
-const isDev = process.env.NODE_ENV !== 'production';
-
 const cssRegex = /(?:\.css)$/;
 const jsRegex = /(?:\.js)$/;
 
@@ -110,7 +108,7 @@ class HtmlIncludeChunksWebpackPlugin {
 			.filter((file) => file.match(cssRegex))
 			.map(this.getLinkTag);
 		const scripts = allFiles
-			.filter((file) => isDev || file.match(jsRegex))
+			.filter((file) => file.match(jsRegex))
 			.map(this.getScriptTag);
 
 		return {


### PR DESCRIPTION
Hey, thanks for publishing this. We have a similar multi-page setup, and I was doing something like this until it broke in html-webpack-plugin v4. I'd love to use this project as a dependency instead.

Currently, all file assets generate a script tag in dev environments. I'm not sure if this is intentional, but I end up with things like
```html
<script src="/vendor.css"></script>
```
in my HTML markup.

The simplest fix I can see is to just remove the `isDev` check while filtering script assets. Let me know if this works.